### PR TITLE
Center disabled HTTP access on January 13, 2020

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <repositories>
         <repository>
             <id>JCenter</id>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
         <repository>
             <id>jitpack.io</id>


### PR DESCRIPTION
Per Article at [https://jfrog.com/blog/secure-jcenter-with-https/](https://jfrog.com/blog/secure-jcenter-with-https/)  JCenter disabled HTTP access on January 13, 2020