### PR TITLE
Fix wiki search with spaces and for URLs, fixes #5

### DIFF
--- a/src/main/java/wiresegal/wob/plugin/PluginHandlerFramework.kt
+++ b/src/main/java/wiresegal/wob/plugin/PluginHandlerFramework.kt
@@ -22,7 +22,8 @@ typealias InputPredicate = (content: String, trimmed: String, stripped: String, 
 typealias InputFunction = (content: String, trimmed: String, stripped: String, message: Message) -> Unit
 
 data class TextHandler(val matches: InputPredicate,
-                       val handle: InputFunction)
+                       val handle: InputFunction,
+                       val caseSensitive: Boolean)
 
 data class DocumentedCommand(val matches: (Message) -> Boolean,
                              val name: String)
@@ -30,75 +31,75 @@ data class DocumentedCommand(val matches: (Message) -> Boolean,
 val textHandlers = mutableListOf<TextHandler>()
 val visibleCommands = mutableListOf<DocumentedCommand>()
 
-fun addHiddenCommand(keyword: String, handle: InputFunction) {
-    textHandlers.add(TextHandler({ it, _, _, _ -> it.startsWith("!$keyword ") || it == "!$keyword" }, handle))
+fun addHiddenCommand(keyword: String, caseSensitive: Boolean = false, handle: InputFunction) {
+    textHandlers.add(TextHandler({ it, _, _, _ -> it.startsWith("!$keyword ") || it == "!$keyword" }, handle, caseSensitive))
 }
 
-fun addHiddenCommand(keyword: String, alias: List<String>, handle: InputFunction) {
-    addHiddenCommand(keyword, handle)
+fun addHiddenCommand(keyword: String, alias: List<String>, caseSensitive: Boolean = false, handle: InputFunction) {
+    addHiddenCommand(keyword, caseSensitive, handle)
     for (a in alias)
-        addHiddenCommand(a, handle)
+        addHiddenCommand(a, caseSensitive, handle)
 }
 
-fun addHiddenAdminCommand(keyword: String, handle: InputFunction) {
-    textHandlers.add(TextHandler({ it, _, _, msg -> msg.checkPermissions(BotRanks.ADMIN) && (it.startsWith("!$keyword ") || it == "!$keyword") }, handle))
+fun addHiddenAdminCommand(keyword: String, caseSensitive: Boolean = false, handle: InputFunction) {
+    textHandlers.add(TextHandler({ it, _, _, msg -> msg.checkPermissions(BotRanks.ADMIN) && (it.startsWith("!$keyword ") || it == "!$keyword") }, handle, caseSensitive))
 }
 
-fun addHiddenAdminCommand(keyword: String, alias: List<String>, handle: InputFunction) {
-    addHiddenAdminCommand(keyword, handle)
+fun addHiddenAdminCommand(keyword: String, alias: List<String>, caseSensitive: Boolean = false, handle: InputFunction) {
+    addHiddenAdminCommand(keyword, caseSensitive, handle)
     for (a in alias)
-        addHiddenAdminCommand(a, handle)
+        addHiddenAdminCommand(a, caseSensitive, handle)
 }
 
-fun addCommand(keyword: String, handle: InputFunction) {
+fun addCommand(keyword: String, caseSensitive: Boolean = false, handle: InputFunction) {
     visibleCommands.add(DocumentedCommand({ true }, "!$keyword"))
-    addHiddenCommand(keyword, handle)
+    addHiddenCommand(keyword, caseSensitive, handle)
 }
 
-fun addCommand(keyword: String, alias: List<String>, handle: InputFunction) {
-    addCommand(keyword, handle)
+fun addCommand(keyword: String, alias: List<String>, caseSensitive: Boolean = false, handle: InputFunction) {
+    addCommand(keyword, caseSensitive, handle)
     for (a in alias)
-        addHiddenCommand(a, handle)
+        addHiddenCommand(a, caseSensitive, handle)
 }
 
-fun addAdminCommand(keyword: String, handle: InputFunction) {
+fun addAdminCommand(keyword: String, caseSensitive: Boolean = false, handle: InputFunction) {
     visibleCommands.add(DocumentedCommand({ it.checkPermissions(BotRanks.ADMIN) }, "!$keyword (Admin only)"))
-    addHiddenAdminCommand(keyword, handle)
+    addHiddenAdminCommand(keyword, caseSensitive, handle)
 }
 
-fun addAdminCommand(keyword: String, alias: List<String>, handle: InputFunction) {
-    addAdminCommand(keyword, handle)
+fun addAdminCommand(keyword: String, alias: List<String>, caseSensitive: Boolean = false, handle: InputFunction) {
+    addAdminCommand(keyword, caseSensitive, handle)
     for (a in alias)
-        addHiddenAdminCommand(a, handle)
+        addHiddenAdminCommand(a, caseSensitive, handle)
 }
 
-fun addSoftHiddenCommand(keyword: String, handle: InputFunction) {
+fun addSoftHiddenCommand(keyword: String, caseSensitive: Boolean = false, handle: InputFunction) {
     visibleCommands.add(DocumentedCommand({ it.checkPermissions(BotRanks.ADMIN) }, "!$keyword"))
-    addHiddenCommand(keyword, handle)
+    addHiddenCommand(keyword, caseSensitive, handle)
 }
 
-fun addSoftHiddenCommand(keyword: String, alias: List<String>, handle: InputFunction) {
-    addSoftHiddenCommand(keyword, handle)
+fun addSoftHiddenCommand(keyword: String, alias: List<String>, caseSensitive: Boolean = false, handle: InputFunction) {
+    addSoftHiddenCommand(keyword, caseSensitive, handle)
     for (a in alias)
-        addHiddenCommand(a, handle)
+        addHiddenCommand(a, caseSensitive, handle)
 }
 
 fun addCalloutHandler(callout: String, handle: InputFunction) {
     visibleCommands.add(DocumentedCommand({ true }, callout))
     val call = callout.replace("\\W".toRegex(), "").toLowerCase()
-    textHandlers.add(TextHandler({ _, _, it, _ -> it.startsWith(call) }, handle))
+    textHandlers.add(TextHandler({ _, _, it, _ -> it.startsWith(call) }, handle, false))
 }
 
 fun addHiddenCalloutHandler(callout: String, handle: InputFunction) {
     val call = callout.replace("\\W".toRegex(), "").toLowerCase()
-    textHandlers.add(TextHandler({ _, _, it, _ -> it.startsWith(call) }, handle))
+    textHandlers.add(TextHandler({ _, _, it, _ -> it.startsWith(call) }, handle, false))
 }
 
 fun addMultiCalloutHandler(callouts: List<String>, handle: InputFunction) {
     val calls = callouts.map { it.replace("\\W".toRegex(), "").toLowerCase() }
-    textHandlers.add(TextHandler({ _, _, str, _ -> calls.all { it in str } }, handle))
+    textHandlers.add(TextHandler({ _, _, str, _ -> calls.all { it in str } }, handle, false))
 }
 
 fun addExactCalloutHandler(callout: String, handle: InputFunction) {
-    textHandlers.add(TextHandler({ it, _, _, _ -> it == callout }, handle))
+    textHandlers.add(TextHandler({ it, _, _, _ -> it == callout }, handle, false))
 }


### PR DESCRIPTION
This PR addresses two issues:

 1. It fixes #5, titles for wiki pages with spaces are now correctly retrieved with an underscore rather than a plus as separator
 2. The retrieval of articles via their URL did not work previously, for two reasons:
     1. The regex for the URL was slightly wrong, having it matching single characters rather than whole page titles
     2. Commands were always handled without regard for casing, but MediaWiki/the Coppermind has case sensitive page titles. This is fixed by allowing a command to declare itself case sensitive in general (but only for the main content, not for the trimmed)

The retrieval of direct URLs was also improved by displaying a loading message while the request is in progress.