### PR TITLE
Fix role access by specifying required gateway intents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,13 +186,13 @@
         <dependency>
             <groupId>org.javacord</groupId>
             <artifactId>javacord</artifactId>
-            <version>3.1.1</version>
+            <version>3.3.2</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.javacord</groupId>
             <artifactId>javacord-core</artifactId>
-            <version>3.1.1</version>
+            <version>3.3.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/wiresegal/wob/WordsOfBrandon.kt
+++ b/src/main/java/wiresegal/wob/WordsOfBrandon.kt
@@ -2,6 +2,7 @@ package wiresegal.wob
 
 import org.javacord.api.DiscordApi
 import org.javacord.api.DiscordApiBuilder
+import org.javacord.api.entity.intent.Intent
 import org.javacord.api.entity.message.embed.EmbedBuilder
 import org.javacord.core.util.logging.LoggerUtil
 import wiresegal.wob.arcanum.notifyOwners
@@ -17,7 +18,17 @@ import java.time.Instant
  * Created at 9:12 PM on 1/25/18.
  */
 
-private val apiProvider = DiscordApiBuilder().setToken(token).login()
+private val apiProvider = DiscordApiBuilder()
+    .setToken(token)
+    .setIntents(
+        Intent.GUILDS,
+        Intent.GUILD_MEMBERS,
+        Intent.GUILD_MESSAGES,
+        Intent.GUILD_MESSAGE_REACTIONS,
+        Intent.DIRECT_MESSAGES,
+        Intent.DIRECT_MESSAGE_REACTIONS
+    )
+    .login()
 
 val api: DiscordApi by lazy { apiProvider.join() }
 

--- a/src/main/java/wiresegal/wob/plugin/PluginUtils.kt
+++ b/src/main/java/wiresegal/wob/plugin/PluginUtils.kt
@@ -107,7 +107,7 @@ fun Messageable.sendError(replyingTo: String, message: String, error: Throwable)
 
     val location = when (this) {
         is Mentionable -> "in " + this.mentionTag + "\n"
-        is PrivateChannel -> "in " + this.recipient.mentionTag + "\n"
+        is PrivateChannel -> "in " + (this.recipient.orElse(null)?.mentionTag?.plus("\n") ?: "")
         is GroupChannel -> "in " + (this.name.orElse(null)?.plus("\n") ?: "") +
                 this.members.joinToString { it.mentionTag } + "\n"
         else -> ""
@@ -143,7 +143,7 @@ fun Messageable.sendError(replyingTo: String, message: String, error: Throwable)
     val wireID = 77084495118868480L
     val ownerID = api.ownerId
 
-    val myId = (this as? User)?.id ?: (this as? PrivateChannel)?.recipient?.id
+    val myId = (this as? User)?.id ?: (this as? PrivateChannel)?.recipient?.orElse(null)?.id
 
     if ((myId == wireID && wobCommand == "wob") || myId == ownerID) {
         sendTo(replyingTo, "message")


### PR DESCRIPTION
It appears that updating Javacord as part of 306b1e7eecd7adc20e9c39cf1cbe9b36e6e670bb also bumped the used API version to over v6, which means the bot now needs to specify the Gateway Intents it requires. As we access member roles for permission checks, we need the privileged `GUILD_MEMBERS` intent.

Since we haven't specified intents so far and Javacord doesn't enable privileged intents by default (for obvious reasons), this lead to an issue where users with e.g. the "Manage messages" permissions weren't able to delete WoBs by reacting or to use the various emotion callouts.

I've also updated Javacord to the latest version so we are current with the Discord API.

**NOTE**: This is a breaking change, as we now require a privileged intent that bot owners need to enable. FYI @m-strzelczyk you can do that in preparation before we merge this.