### PR TITLE
Spoiler-tag response if request is spoiler-tagged

### DIFF
--- a/src/main/java/wiresegal/wob/WordsOfBrandon.kt
+++ b/src/main/java/wiresegal/wob/WordsOfBrandon.kt
@@ -32,7 +32,7 @@ private val apiProvider = DiscordApiBuilder()
 
 val api: DiscordApi by lazy { apiProvider.join() }
 
-data class EmbeddedInfo(val user: Long, val channel: Long, val index: Int, val embeds: List<EmbedBuilder>)
+data class EmbeddedInfo(val user: Long, val channel: Long, val index: Int, val shouldHide: Boolean, val embeds: List<EmbedBuilder>)
 
 val messagesWithEmbedLists by lazy {
     SavedTypedMap<Long, EmbeddedInfo>(fileInHome("wob_bot_messages"),

--- a/src/main/java/wiresegal/wob/misc/util/Embed.kt
+++ b/src/main/java/wiresegal/wob/misc/util/Embed.kt
@@ -5,3 +5,5 @@ import org.javacord.api.entity.message.embed.EmbedBuilder
 import org.javacord.core.entity.message.embed.EmbedBuilderDelegateImpl
 
 fun EmbedBuilder.toJsonNode(): ObjectNode = (delegate as EmbedBuilderDelegateImpl).toJsonNode()
+
+fun String.spoilerTag(shouldTag: Boolean) = if (shouldTag) "||${this}||" else this

--- a/src/main/java/wiresegal/wob/plugin/PluginUtils.kt
+++ b/src/main/java/wiresegal/wob/plugin/PluginUtils.kt
@@ -49,7 +49,7 @@ fun TextChannel.sendRandomEmbed(requester: DiscordEntity, title: String, color: 
     val index = (Math.random() * embeds.size).toInt()
     val embed = embeds[index]
 
-    sendMessage(embed).setupDeletable(requester).setupControls(requester, index, embeds)
+    sendMessage(embed).setupDeletable(requester).setupControls(requester, index, false, embeds)
 }
 
 fun TextChannel.sendRandomEmbed(requester: DiscordEntity, title: String, messages: Array<Pair<String, Pair<String, Color>>>) {
@@ -58,7 +58,7 @@ fun TextChannel.sendRandomEmbed(requester: DiscordEntity, title: String, message
     val index = (Math.random() * embeds.size).toInt()
     val embed = embeds[index]
 
-    sendMessage(embed).setupDeletable(requester).setupControls(requester, index, embeds)
+    sendMessage(embed).setupDeletable(requester).setupControls(requester, index, false, embeds)
 }
 
 fun Message.sendMinorError(message: String) {


### PR DESCRIPTION
Check is very basic, it just searches to see if the command (`wob` or `cm`/`coppermind` are the only keywords supporting it currently) is between a pair of `||` or not (or rather, whether if you split on every instance of that string, it's in an odd-numbered position), and if so, appends `||` to the start and end of every field + description + title. 

Not sure if this is the way we'd want to do it or not (as opposed to implementing it in the framework so _any_ command gets it), but it works.